### PR TITLE
made config setting IncludeDir optional

### DIFF
--- a/src/rc.c
+++ b/src/rc.c
@@ -241,7 +241,7 @@ init_config (char *filename)
   CONFIG_STR (__GLOBAL_INCLUDE_FILE__) =
     scan_config (config, "GlobalInclude", 0, NULL);
   CONFIG_STR (__BIN_DIR__) = NULL;
-  CONFIG_STR (__INCLUDE_DIRS__) = scan_config (config, "IncludeDir", 1, NULL);
+  CONFIG_STR (__INCLUDE_DIRS__) = scan_config (config, "IncludeDir", 0, NULL);
   CONFIG_STR (__SAVE_BINARIES_DIR__) =
     scan_config (config, "SaveBinaryDir", 1, NULL);
   CONFIG_STR (__MASTER_FILE__) = scan_config (config, "MasterFile", 1, NULL);


### PR DESCRIPTION
- allows not setting IncludeDir in config file
- forbids non-ANSI characters in the path
- unsafe directory (like ..) is removed from search path, but allows program to continue